### PR TITLE
build(port): use 9900 for local dev and 9901 for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ FROM node:14.15.1-alpine
 ENV HOME_DIR /app
 ENV WHATAMI gha-build-monitor
 ENV NODE_ENV production
+ENV HTTP_PORT 9901
 
 # hadolint ignore=DL3018
 RUN apk --no-cache add ca-certificates

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "check": "npm run tsoa:gen && npm run ts:check && npm run lint",
     "lint": "eslint . --ext .ts",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "start": "INSTALLATION_ID=installation_id_guid node dist/index.js",
-    "start:dev": "INSTALLATION_ID=installation_id_guid  concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
+    "start": "INSTALLATION_ID=installation_id_guid HTTP_PORT=9900 node dist/index.js",
+    "start:dev": "INSTALLATION_ID=installation_id_guid HTTP_PORT=9900 concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
     "test": "jest",
     "ts:check": "tsc --noEmit --noErrorTruncation ",
     "tsoa:gen": "tsoa spec-and-routes"

--- a/src/api/__testTools__/ApiTestTools.ts
+++ b/src/api/__testTools__/ApiTestTools.ts
@@ -13,6 +13,9 @@ export const TEST_SETTINGS: Settings = Object.freeze({
   catlight: {
     installationId: 'TEST_INSTALLATION_ID',
   },
+  http: {
+    port: 12345,
+  },
 });
 
 function getDependenciesForTesting(partial: Partial<ApiDependencies>): ApiDependencies {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const settings = loadSettingsFromEnvVars();
 const compositionRoot = CompositionRoot.forProd(settings);
 const app = buildWebApp(compositionRoot);
 
-const port = 9901;
+const port = settings.http.port;
 
 // eslint-disable-next-line no-console
 app.listen(port, () => console.log(`app listening at http://localhost:${port}`));

--- a/src/settings-types.ts
+++ b/src/settings-types.ts
@@ -1,7 +1,12 @@
 export interface Settings {
   readonly catlight: CatLightSettings;
+  readonly http: HttpSettings;
 }
 
 export interface CatLightSettings {
   readonly installationId: string;
+}
+
+export interface HttpSettings {
+  readonly port: number;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,5 +6,8 @@ export function loadSettingsFromEnvVars(): Settings {
     catlight: {
       installationId: EnvVars.getString('INSTALLATION_ID'),
     },
+    http: {
+      port: EnvVars.getOptionalInteger('HTTP_PORT', 9901),
+    },
   };
 }


### PR DESCRIPTION
so we can run both locally while developing