### PR TITLE
Adapt to Secret access control policy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,9 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      # some tests need credentials when hitting github endpoints - see src/infra/github/__testTools__/secrets.ts.sample
-      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -50,8 +47,17 @@ jobs:
       - name: Typescript linting
         run: npm run lint
 
-      - name: Unit tests
-        run: npm run test
+      - name: Unit tests (no secrets)
+        # dependabot has no access to secrets - cf https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        run: npm run test:no-secrets
+
+      - name: Unit tests (need secrets)
+        # we expect this to be a json
+        if: ${{ contains(env.TEST_CREDENTIALS, '{') }}
+        run: npm run test:need-secrets
+        env:
+          # some tests need credentials when hitting github endpoints - see src/infra/github/__testTools__/secrets.ts.sample
+          TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
 
   build:
     needs: test

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "start": "HTTP_PORT=9900 node dist/index.js",
     "start:dev": "HTTP_PORT=9900 concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
     "test": "jest --testTimeout=15000",
+    "test:no-secrets": "jest --testTimeout=15000 -t='^((?!(#needs-secrets)).)*$' --silent",
+    "test:need-secrets": "jest --testTimeout=15000 -t=#needs-secrets --silent",
     "ts:check": "tsc --noEmit --noErrorTruncation ",
     "tsoa:gen": "tsoa spec-and-routes"
   },

--- a/src/infra/EnvVars.ts
+++ b/src/infra/EnvVars.ts
@@ -34,6 +34,14 @@ export class EnvVars {
     return (JSON.parse(strValue) as unknown) as T;
   }
 
+  public static getOptionalJson<T>(envVarName: string, defaultValue: T): T {
+    const strValue = this.getOptionalString(envVarName, '');
+    if (!strValue) {
+      return defaultValue;
+    }
+    return (JSON.parse(strValue) as unknown) as T;
+  }
+
   public static getOptionalBool(envVarName: string, defaultValue: boolean = false): boolean {
     const value = process.env[envVarName];
     if (value === undefined) {

--- a/src/infra/github/__testTools__/TestCredentials.ts
+++ b/src/infra/github/__testTools__/TestCredentials.ts
@@ -7,7 +7,7 @@ try {
   realSecrets = require('./secrets').SECRETS;
   // eslint-disable-next-line no-empty
 } catch {
-  realSecrets = EnvVars.getJson<Partial<Secrets>>('TEST_CREDENTIALS');
+  realSecrets = EnvVars.getOptionalJson<Partial<Secrets>>('TEST_CREDENTIALS', {});
 }
 
 const DEFAULT_SECRETS: Secrets = {

--- a/src/infra/github/__tests__/RepoRepository.spec.ts
+++ b/src/infra/github/__tests__/RepoRepository.spec.ts
@@ -15,7 +15,7 @@ describe('RepoRepository', () => {
     buildInfo: {},
   });
   describe('listForToken', () => {
-    test('should return only public repos when using "no scope" token', async () => {
+    test('should return only public repos when using "no scope" token #needs-secrets', async () => {
       const sut = new RepoRepository(octokitFactory);
 
       const actual = await sut.listForToken(testCredentials.PAT_NO_SCOPE);
@@ -35,7 +35,7 @@ describe('RepoRepository', () => {
       expect(reposWithoutTsimbalar).toHaveLength(0);
     });
 
-    test('should return all repos across multiple organizations when using token with scope "repo"', async () => {
+    test('should return all repos across multiple organizations when using token with scope "repo" #needs-secrets', async () => {
       const sut = new RepoRepository(octokitFactory);
 
       const actual = await sut.listForToken(testCredentials.PAT_SCOPE_REPO);

--- a/src/infra/github/__tests__/UserRepository.spec.ts
+++ b/src/infra/github/__tests__/UserRepository.spec.ts
@@ -10,7 +10,7 @@ describe('UserRepository', () => {
     buildInfo: {},
   });
   describe('getUserFromToken', () => {
-    test('should return user info with valid token', async () => {
+    test('should return user info with valid token #needs-secrets', async () => {
       const sut = new UserRepository(octokitFactory);
 
       const actual = await sut.getUserFromToken(testCredentials.PAT_NO_SCOPE);
@@ -21,7 +21,7 @@ describe('UserRepository', () => {
       });
     });
 
-    test('should return scopes of user with "repo" scope', async () => {
+    test('should return scopes of user with "repo" scope #needs-secrets', async () => {
       const sut = new UserRepository(octokitFactory);
 
       const actual = await sut.getUserFromToken(testCredentials.PAT_SCOPE_REPO);

--- a/src/infra/github/__tests__/WorkflowRunRepository.spec.ts
+++ b/src/infra/github/__tests__/WorkflowRunRepository.spec.ts
@@ -26,7 +26,7 @@ describe('WorkflowRunRepository', () => {
   });
   const emptyCommitAutorRepo = new EmptyCommitAuthorRepo();
   describe('getLatestRunsForWorkflow', () => {
-    test('should retrieve runs of public repo', async () => {
+    test('should retrieve runs of public repo #needs-secrets', async () => {
       const sut = new WorkflowRunRepository(octokitFactory, emptyCommitAutorRepo);
 
       const actual = await sut.getLatestRunsForWorkflow(
@@ -57,7 +57,7 @@ describe('WorkflowRunRepository', () => {
       });
     });
 
-    test('should retrieve authors of commits on public repo', async () => {
+    test('should retrieve authors of commits on public repo #needs-secrets', async () => {
       const sut = new WorkflowRunRepository(
         octokitFactory,
         new CommitAuthorRepository(octokitFactory)
@@ -86,7 +86,7 @@ describe('WorkflowRunRepository', () => {
       });
     }, 20000);
 
-    test('should name branches according to triggering event', async () => {
+    test('should name branches according to triggering event #needs-secrets', async () => {
       const sut = new WorkflowRunRepository(octokitFactory, emptyCommitAutorRepo);
 
       const actual = await sut.getLatestRunsForWorkflow(
@@ -117,7 +117,7 @@ describe('WorkflowRunRepository', () => {
       }
     });
 
-    test('should sort builds from older to newer', async () => {
+    test('should sort builds from older to newer #needs-secrets', async () => {
       const sut = new WorkflowRunRepository(octokitFactory, emptyCommitAutorRepo);
 
       const actual = await sut.getLatestRunsForWorkflow(
@@ -139,7 +139,7 @@ describe('WorkflowRunRepository', () => {
       expect(oldestRun.startTime.getTime()).toBeLessThan(secondOldestRun.startTime.getTime());
     });
 
-    test('should apply maxAgeInDays', async () => {
+    test('should apply maxAgeInDays #needs-secrets', async () => {
       const maxAgeInDays = 3;
       const sut = new WorkflowRunRepository(octokitFactory, emptyCommitAutorRepo);
 
@@ -161,7 +161,7 @@ describe('WorkflowRunRepository', () => {
       expect(oldestRun.startTime.getTime()).toBeGreaterThan(nDaysAgo.getTime());
     });
 
-    test('should apply maxRunsPerBranch in repo with lots of activity', async () => {
+    test('should apply maxRunsPerBranch in repo with lots of activity #needs-secrets', async () => {
       const maxRunsPerBranch = 2;
       const sut = new WorkflowRunRepository(octokitFactory, emptyCommitAutorRepo);
 


### PR DESCRIPTION
Dependabot PR no longer have the secrets... 

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
and
https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/