### PR TITLE
Do not return "skipped" runs

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -310,7 +310,7 @@ components:
             bearerFormat: JWT
 info:
     title: gha-build-monitor
-    version: 0.9.2
+    version: 0.10.0
     description: 'Adapter to give access to GitHub Actions status via the CatLight Protocol'
     license:
         name: MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-build-monitor",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-build-monitor",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "buildInfo": {
     "commitSha": "_CI_GIT_COMMIT_SHA",
     "buildDate": "_CI_BUILD_DATE",


### PR DESCRIPTION
Up until now they were considered "failed" , causing lots of read, and also adding lots of noise in CatLight.